### PR TITLE
feat: #20 add send action proposal

### DIFF
--- a/src/api/bank.messages.ts
+++ b/src/api/bank.messages.ts
@@ -1,0 +1,27 @@
+import { cosmos } from '@haveanicedavid/regen-ts'
+
+import type { Any } from 'types'
+
+/** NOTE: Can't use the msgComposer here, as these messages will be nested into a proposal's `messages` field. Need to manually set `typUrl` and an encoded `value` */
+
+export function msgSend({
+  fromAddress,
+  toAddress,
+  denom,
+  amount,
+}: {
+  fromAddress: string
+  toAddress: string
+  denom: string
+  amount: string
+}): Any {
+  const value = cosmos.bank.v1beta1.MsgSend.encode({
+    fromAddress,
+    toAddress,
+    amount: [{ denom, amount }], // TODO: support multiple coins?
+  }).finish()
+  return {
+    typeUrl: '/cosmos.bank.v1beta1.MsgSend',
+    value,
+  }
+}

--- a/src/api/proposal.utils.ts
+++ b/src/api/proposal.utils.ts
@@ -99,7 +99,7 @@ function isSendProposal(
 
 function sendValuesToMsg(values: ProposalSendFormValues, data: ProposalData) {
   const sendInfo = {
-    fromAddress: data.groupPolicyAddress, // TODO: should this be a different address?
+    fromAddress: data.groupPolicyAddress,
     toAddress: values.toAddress,
     amount: values.amount,
     denom: data.denom,
@@ -119,7 +119,7 @@ function stakeValuesToMsg(values: ProposalStakeFormValues, data: ProposalData) {
       amount: values.amount,
       validatorAddress: values.validator,
       denom: data.denom,
-      delegatorAddress: data.groupPolicyAddress, // TODO: should this be a different address?
+      delegatorAddress: data.groupPolicyAddress,
     }
     return values.stakeType === 'delegate'
       ? msgStakingDelegate(delegateInfo)

--- a/src/components/organisms/proposal-form.tsx
+++ b/src/components/organisms/proposal-form.tsx
@@ -130,6 +130,7 @@ export const ProposalForm = (props: {
           <ProposalSendForm
             defaultValues={action.values as ProposalSendFormValues}
             formId={action.id}
+            // TODO: maxAmount should probably be dynamic, or set by searching balances
             maxAmount={props.policyBalances[0]?.amount}
             onError={() => handleFormError(action.id)}
             onSubmit={(data) => updateActionValues(action.id, data)}

--- a/src/components/organisms/proposal-form.tsx
+++ b/src/components/organisms/proposal-form.tsx
@@ -1,8 +1,13 @@
 import { useCallback, useEffect, useState } from 'react'
 import { omit } from 'remeda'
 
-import type { ProposalAction, ProposalStakeFormValues, UICoin } from 'types'
-import { defaultStakeFormValues } from 'util/form.defaults'
+import type {
+  ProposalAction,
+  ProposalSendFormValues,
+  ProposalStakeFormValues,
+  UICoin,
+} from 'types'
+import { defaultSendFormValues, defaultStakeFormValues } from 'util/form.defaults'
 import { uuid } from 'util/helpers'
 
 import { useDisclosure } from 'hooks/chakra-hooks'
@@ -13,6 +18,7 @@ import { EditableDescription, EditableHeading } from '@/molecules/editable'
 import { FormSubmitHiddenButton } from '@/molecules/form-footer'
 import { WithRemoveButton } from '@/molecules/with-remove-button'
 import { ProposalActionDrawer } from '@/organisms/proposal-action-drawer'
+import { ProposalSendForm } from '@/organisms/proposal-send-form'
 import { ProposalStakeForm } from '@/organisms/proposal-stake-form'
 
 export type ProposalFormValues = {
@@ -67,6 +73,9 @@ export const ProposalForm = (props: {
     // actions in a single proposal. IDs are passed to the downstream `<form>`
     // elements so they can be manually submitted (see: `handleSubmitAllForms`)
     switch (actionType) {
+      case 'send':
+        setActions([...actions, { id, type: 'send', values: defaultSendFormValues }])
+        break
       case 'stake':
         setActions([...actions, { id, type: 'stake', values: defaultStakeFormValues }])
         break
@@ -116,13 +125,23 @@ export const ProposalForm = (props: {
 
   function renderAction(action: ProposalAction) {
     switch (action.type) {
+      case 'send':
+        return (
+          <ProposalSendForm
+            defaultValues={action.values as ProposalSendFormValues}
+            formId={action.id}
+            maxAmount={props.policyBalances[0]?.amount}
+            onError={() => handleFormError(action.id)}
+            onSubmit={(data) => updateActionValues(action.id, data)}
+          />
+        )
       case 'stake':
         return (
           <ProposalStakeForm
             defaultValues={action.values as ProposalStakeFormValues}
             formId={action.id}
             // TODO: maxStakeAmount should probably be dynamic, or set by searching balances for the stake denom
-            maxStakeAmount={props.policyBalances[0].amount}
+            maxStakeAmount={props.policyBalances[0]?.amount}
             onError={() => handleFormError(action.id)}
             onSubmit={(data) => updateActionValues(action.id, data)}
           />

--- a/src/components/organisms/proposal-send-form.tsx
+++ b/src/components/organisms/proposal-send-form.tsx
@@ -1,60 +1,65 @@
-import { useSnapshot } from 'valtio'
-import { z } from 'zod'
+import { useState } from 'react'
 
+import type { ProposalSendFormValues, ProposalSendType } from 'types'
 import { SPACING } from 'util/constants'
-import { getFeeDenom } from 'util/helpers'
-import { valid } from 'util/validation/zod'
 
-import { useZodForm } from 'hooks/use-zod-form'
-import { Chain } from 'store/chain.store'
-
-import { Stack } from '@/atoms'
-import { Form } from '@/molecules/form'
+import { FormControl, FormLabel, RadioGroup, Stack } from '@/atoms'
 import { FormCard } from '@/molecules/form-card'
-import { AmountField, FeeDisplayField, InputField } from '@/molecules/form-fields'
-import { FormSubmitHiddenButton } from '@/molecules/form-footer'
+import { RadioGroupOptions } from '@/molecules/radio-group-options'
 
-const schema = z.object({
-  toAddress: valid.bech32Address,
-  amount: valid.amount,
-})
+import { type SingleFormValues, SingleForm } from './send-single-form'
 
-export type ProposalSendFormValues = z.infer<typeof schema>
+const sendOptions: { label: string; value: ProposalSendType }[] = [
+  { label: 'Single', value: 'single' },
+  // { label: 'Multiple', value: 'multi' }, // TODO
+]
 
-export const ProposalSendForm = (props: {
+export const ProposalSendForm = ({
+  defaultValues,
+  formId,
+  maxAmount,
+  onError,
+  onSubmit,
+}: {
   defaultValues: ProposalSendFormValues
   formId: string
   maxAmount: string
-  onSubmit: (data: ProposalSendFormValues) => void
   onError: () => void
+  onSubmit: (values: ProposalSendFormValues) => void
 }) => {
-  const { fee } = useSnapshot(Chain)
-  const form = useZodForm({
-    schema,
-    defaultValues: {
-      ...props.defaultValues,
-    },
-  })
+  const [sendType, setSendType] = useState<ProposalSendType>('single')
+  function renderForm() {
+    const baseProps = {
+      formId,
+      onSubmit,
+      onError,
+      maxAmount,
+    }
+    switch (sendType) {
+      case 'single':
+      default:
+        return (
+          <SingleForm
+            {...baseProps}
+            key={formId + '-single'} // force re-render when toggling between forms
+            defaultValues={defaultValues as SingleFormValues}
+          />
+        )
+    }
+  }
   return (
     <FormCard title="Send">
       <Stack spacing={SPACING.formStack}>
-        <Form
-          id={props.formId}
-          form={form}
-          onSubmit={props.onSubmit}
-          onError={props.onError}
-        >
-          <InputField required name="to-address" label="To Address" />
-          <AmountField
-            required
-            name="amount"
-            label="Amount"
-            maxValue={props.maxAmount}
-            denom={getFeeDenom(fee)}
-          />
-          <FeeDisplayField />
-          <FormSubmitHiddenButton id={props.formId} onSubmit={props.onSubmit} />
-        </Form>
+        {/*<FormControl>*/}
+        {/*  <FormLabel>Type</FormLabel>*/}
+        {/*  <RadioGroup*/}
+        {/*    onChange={(val) => setSendType(val as ProposalSendType)}*/}
+        {/*    defaultValue={sendType}*/}
+        {/*  >*/}
+        {/*    <RadioGroupOptions options={sendOptions} selected={sendType} />*/}
+        {/*  </RadioGroup>*/}
+        {/*</FormControl>*/}
+        {renderForm()}
       </Stack>
     </FormCard>
   )

--- a/src/components/organisms/proposal-send-form.tsx
+++ b/src/components/organisms/proposal-send-form.tsx
@@ -1,0 +1,61 @@
+import { useSnapshot } from 'valtio'
+import { z } from 'zod'
+
+import { SPACING } from 'util/constants'
+import { getFeeDenom } from 'util/helpers'
+import { valid } from 'util/validation/zod'
+
+import { useZodForm } from 'hooks/use-zod-form'
+import { Chain } from 'store/chain.store'
+
+import { Stack } from '@/atoms'
+import { Form } from '@/molecules/form'
+import { FormCard } from '@/molecules/form-card'
+import { AmountField, FeeDisplayField, InputField } from '@/molecules/form-fields'
+import { FormSubmitHiddenButton } from '@/molecules/form-footer'
+
+const schema = z.object({
+  toAddress: valid.bech32Address,
+  amount: valid.amount,
+})
+
+export type ProposalSendFormValues = z.infer<typeof schema>
+
+export const ProposalSendForm = (props: {
+  defaultValues: ProposalSendFormValues
+  formId: string
+  maxAmount: string
+  onSubmit: (data: ProposalSendFormValues) => void
+  onError: () => void
+}) => {
+  const { fee } = useSnapshot(Chain)
+  const form = useZodForm({
+    schema,
+    defaultValues: {
+      ...props.defaultValues,
+    },
+  })
+  return (
+    <FormCard title="Send">
+      <Stack spacing={SPACING.formStack}>
+        <Form
+          id={props.formId}
+          form={form}
+          onSubmit={props.onSubmit}
+          onError={props.onError}
+        >
+          <InputField required name="to-address" label="To Address" />
+          <AmountField
+            required
+            name="amount"
+            label="Amount"
+            maxValue={props.maxAmount}
+            denom={getFeeDenom(fee)}
+          />
+          <FeeDisplayField />
+          <FormSubmitHiddenButton id={props.formId} onSubmit={props.onSubmit} />
+        </Form>
+      </Stack>
+    </FormCard>
+  )
+}

--- a/src/components/organisms/send-single-form.tsx
+++ b/src/components/organisms/send-single-form.tsx
@@ -1,0 +1,50 @@
+import { useSnapshot } from 'valtio'
+import { z } from 'zod'
+
+import { getFeeDenom } from 'util/helpers'
+import { valid } from 'util/validation/zod'
+
+import { useZodForm } from 'hooks/use-zod-form'
+import { Chain } from 'store/chain.store'
+
+import { Form } from '@/molecules/form'
+import { AmountField, FeeDisplayField, InputField } from '@/molecules/form-fields'
+import { FormSubmitHiddenButton } from '@/molecules/form-footer'
+
+const schema = z.object({
+  toAddress: valid.bech32Address,
+  amount: valid.amount,
+  sendType: z.literal('single'),
+})
+
+export type SingleFormValues = z.infer<typeof schema>
+
+export const SingleForm = (props: {
+  defaultValues: SingleFormValues
+  formId: string
+  maxAmount: string
+  onSubmit: (data: SingleFormValues) => void
+  onError: () => void
+}) => {
+  const { fee } = useSnapshot(Chain)
+  const form = useZodForm({
+    schema,
+    defaultValues: {
+      ...props.defaultValues,
+    },
+  })
+  return (
+    <Form id={props.formId} form={form} onSubmit={props.onSubmit} onError={props.onError}>
+      <InputField required name="toAddress" label="To Address" />
+      <AmountField
+        required
+        name="amount"
+        label="Amount"
+        maxValue={props.maxAmount}
+        denom={getFeeDenom(fee)}
+      />
+      <FeeDisplayField />
+      <FormSubmitHiddenButton id={props.formId} onSubmit={props.onSubmit} />
+    </Form>
+  )
+}

--- a/src/pages/proposal-create-page.tsx
+++ b/src/pages/proposal-create-page.tsx
@@ -3,7 +3,7 @@ import { useSnapshot } from 'valtio'
 
 import type { ProposalAction, ProposalFormValues } from 'types'
 import { handleError, throwError } from 'util/errors'
-import { defaultDelegateFormValues } from 'util/form.defaults'
+import { defaultDelegateFormValues, defaultSendFormValues } from 'util/form.defaults'
 import { getFeeDenom, uuid } from 'util/helpers'
 
 import { createProposal } from 'api/proposal.actions'
@@ -44,6 +44,8 @@ export default function ProposalCreate() {
   function getInitialFormAction(): ProposalAction | null {
     const id = uuid()
     switch (state?.newProposalType) {
+      case 'send':
+        return { id, type: 'send', values: defaultSendFormValues }
       case 'stake':
         return { id, type: 'stake', values: defaultDelegateFormValues }
       default:

--- a/src/types/proposal.types.ts
+++ b/src/types/proposal.types.ts
@@ -30,7 +30,7 @@ export type ProposalAction = {
   /** for handling add / remove behavior + passing to nested forms for submit handler */
   id: string
   type: 'send' | 'stake' | 'text' // TODO: add other event types
-  values: ProposalSendFormValues | ProposalStakeFormValues // TODO types for other form actions
+  values: ProposalSendFormValues | ProposalStakeFormValues // TODO: types for other form actions
 }
 
 export type ProposalStakeType = 'delegate' | 'redelegate' | 'undelegate' | 'claim'

--- a/src/types/proposal.types.ts
+++ b/src/types/proposal.types.ts
@@ -1,5 +1,6 @@
 import type { Proposal } from '@haveanicedavid/regen-ts/types/codegen/cosmos/group/v1/types'
 
+import type { ProposalSendFormValues } from '@/organisms/proposal-send-form'
 import type { ClaimFormValues } from '@/organisms/stake-claim-form'
 import type { DelegateFormValues } from '@/organisms/stake-delegate-form'
 import type { RedelegateFormValues } from '@/organisms/stake-redelegate-form'
@@ -28,8 +29,8 @@ export interface UIProposal
 export type ProposalAction = {
   /** for handling add / remove behavior + passing to nested forms for submit handler */
   id: string
-  type: 'stake' | 'text' // | 'spend' // TODO: add other event types
-  values: ProposalStakeFormValues // TODO types for other form actions
+  type: 'send' | 'stake' | 'text' // TODO: add other event types
+  values: ProposalSendFormValues | ProposalStakeFormValues // TODO types for other form actions
 }
 
 export type ProposalStakeType = 'delegate' | 'redelegate' | 'undelegate' | 'claim'
@@ -40,5 +41,6 @@ export type ProposalStakeFormValues =
   | RedelegateFormValues
 
 // Re-export for convenience
+export type { ProposalSendFormValues }
 export type { ClaimFormValues, DelegateFormValues, RedelegateFormValues }
 export type { ProposalFormValues } from '@/organisms/proposal-form'

--- a/src/types/proposal.types.ts
+++ b/src/types/proposal.types.ts
@@ -1,6 +1,6 @@
 import type { Proposal } from '@haveanicedavid/regen-ts/types/codegen/cosmos/group/v1/types'
 
-import type { ProposalSendFormValues } from '@/organisms/proposal-send-form'
+import type { SingleFormValues } from '@/organisms/send-single-form'
 import type { ClaimFormValues } from '@/organisms/stake-claim-form'
 import type { DelegateFormValues } from '@/organisms/stake-delegate-form'
 import type { RedelegateFormValues } from '@/organisms/stake-redelegate-form'
@@ -33,6 +33,10 @@ export type ProposalAction = {
   values: ProposalSendFormValues | ProposalStakeFormValues // TODO: types for other form actions
 }
 
+export type ProposalSendType = 'single' // TODO: "multi" send
+
+export type ProposalSendFormValues = SingleFormValues // TODO: "multi" send
+
 export type ProposalStakeType = 'delegate' | 'redelegate' | 'undelegate' | 'claim'
 
 export type ProposalStakeFormValues =
@@ -41,6 +45,6 @@ export type ProposalStakeFormValues =
   | RedelegateFormValues
 
 // Re-export for convenience
-export type { ProposalSendFormValues }
+export type { SingleFormValues }
 export type { ClaimFormValues, DelegateFormValues, RedelegateFormValues }
 export type { ProposalFormValues } from '@/organisms/proposal-form'

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -16,15 +16,15 @@ export const ENABLED_ACTIONS: Array<{
   icon: IconType
 }> = [
   {
-    type: 'stake',
-    label: 'Stake',
-    tooltip: 'Create a "stake" proposal',
-    icon: CgListTree,
-  },
-  {
     type: 'send',
     label: 'Send',
     tooltip: 'Create a "send" proposal',
+    icon: CgListTree,
+  },
+  {
+    type: 'stake',
+    label: 'Stake',
+    tooltip: 'Create a "stake" proposal',
     icon: CgListTree,
   },
 ]

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -21,4 +21,10 @@ export const ENABLED_ACTIONS: Array<{
     tooltip: 'Create a "stake" proposal',
     icon: CgListTree,
   },
+  {
+    type: 'send',
+    label: 'Send',
+    tooltip: 'Create a "send" proposal',
+    icon: CgListTree,
+  },
 ]

--- a/src/util/form.defaults.ts
+++ b/src/util/form.defaults.ts
@@ -4,6 +4,7 @@ import type {
   GroupFormValues,
   GroupPolicyFormValues,
   MemberFormValues,
+  ProposalSendFormValues,
   ProposalStakeFormValues,
   RedelegateFormValues,
 } from 'types'
@@ -29,6 +30,11 @@ export const DEFAULT_MEMBER_WEIGHT = 1
 
 export const defaultGroupPolicyFormValues: GroupPolicyFormValues = {
   votingWindow: DEFAULT_VOTING_WINDOW,
+}
+
+export const defaultSendFormValues: ProposalSendFormValues = {
+  toAddress: '',
+  amount: '',
 }
 
 export const defaultDelegateFormValues: DelegateFormValues = {

--- a/src/util/form.defaults.ts
+++ b/src/util/form.defaults.ts
@@ -35,6 +35,7 @@ export const defaultGroupPolicyFormValues: GroupPolicyFormValues = {
 export const defaultSendFormValues: ProposalSendFormValues = {
   toAddress: '',
   amount: '',
+  sendType: 'single',
 }
 
 export const defaultDelegateFormValues: DelegateFormValues = {

--- a/src/util/validation/zod.ts
+++ b/src/util/validation/zod.ts
@@ -37,6 +37,8 @@ const boolStr = z.union([z.literal('true'), z.literal('false')])
 const url = z.string().url('Must be a valid URL')
 const positiveNumStrRegex = /^[+]?([.]\d+|\d+[.]?\d*)$/
 const amount = z.string().regex(positiveNumStrRegex, 'Must be a positive number')
+const denomStrRegex = /^[a-zA-Z][a-zA-Z0-9/:._-]{2,127}$/
+const denom = z.string().regex(denomStrRegex, 'Must be a valid denomination')
 
 // unions
 
@@ -59,6 +61,7 @@ export const valid = {
   admin,
   amount,
   bech32Address,
+  denom,
   emptyStr,
   boolStr,
   name,


### PR DESCRIPTION
Closes #20

This pull request adds the send action proposal create flow using stake action proposal as a reference. I originally set this up with a single send proposal but decided we may want to support multi send in the future (i.e. `MsgMultiSend`), so I restructured this to support multiple send forms and commented out the form selector controls for the time being.

Opened separate issue to add support for "multi" send type: #47