### PR TITLE
feat: #5 change group policy form to use toggle

### DIFF
--- a/src/api/group.messages.ts
+++ b/src/api/group.messages.ts
@@ -17,6 +17,7 @@ export function msgCreateGroupWithPolicy(values: GroupWithPolicyFormValues) {
     policyAsAdmin,
     percentage,
     threshold,
+    policyType,
     votingWindow,
   } = values
   return GroupMsgWithTypeUrl.createGroupWithPolicy({
@@ -24,6 +25,7 @@ export function msgCreateGroupWithPolicy(values: GroupWithPolicyFormValues) {
     groupPolicyMetadata: '',
     groupPolicyAsAdmin: policyAsAdmin === 'true',
     decisionPolicy: encodeDecisionPolicy({
+      policyType,
       percentage: clearEmptyStr(percentage),
       threshold: clearEmptyStr(threshold),
       votingWindow: votingWindow,

--- a/src/components/atoms/chakra-components.ts
+++ b/src/components/atoms/chakra-components.ts
@@ -19,6 +19,8 @@ export type {
   TooltipProps,
 } from '@chakra-ui/react'
 export {
+  type BoxProps,
+  type StackProps,
   Alert,
   AlertDescription,
   AlertIcon,

--- a/src/components/atoms/radio-box.tsx
+++ b/src/components/atoms/radio-box.tsx
@@ -1,9 +1,9 @@
 import { useColorModeValue } from 'hooks/chakra-hooks'
 
 import {
+  type BoxProps,
   type RadioProps,
   Box,
-  Collapse,
   Flex,
   forwardRef,
   Radio,
@@ -12,13 +12,14 @@ import {
 /** Cusom behavior and styles on a `<Radio /> element */
 export const RadioBox = forwardRef<
   RadioProps & {
+    rootProps?: BoxProps
     error?: boolean
     label: string
     selected: boolean
     value: RadioProps['value']
   },
   'div'
->(({ error, children, label, selected, ...radioProps }, ref) => {
+>(({ rootProps, error, children, label, selected, ...radioProps }, ref) => {
   const bgSelected = useColorModeValue('gray.100', 'gray.700')
   const borderSelected = useColorModeValue('blue.300', 'blue.700')
   const borderNormal = useColorModeValue('gray.300', 'gray.600')
@@ -31,16 +32,15 @@ export const RadioBox = forwardRef<
       shadow={selected ? 'md' : undefined}
       bg={selected ? bgSelected : undefined}
       transition="all 0.2s ease-in-out"
-      py={2.5}
-      px={3}
+      py={rootProps?.py || 2.5}
+      px={rootProps?.px || 3}
+      {...rootProps}
     >
       <Flex direction="column">
-        <Radio size="md" value={radioProps.value} w="full" ref={ref}>
+        <Radio w="full" ref={ref} {...radioProps}>
           {label}
         </Radio>
-        <Collapse in={selected} animateOpacity>
-          {children}
-        </Collapse>
+        {children}
       </Flex>
     </Box>
   )

--- a/src/components/atoms/stories/radio-box.stories.tsx
+++ b/src/components/atoms/stories/radio-box.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryFn } from '@storybook/react'
 
-import { Heading, Stack, Text } from '../chakra-components'
+import { Heading, Stack, Text } from '@/atoms'
+
 import { RadioBox } from '../radio-box'
 
 export default {
@@ -9,6 +10,9 @@ export default {
   argTypes: {
     selected: {
       type: 'boolean',
+    },
+    description: {
+      type: 'string',
     },
   },
 } as Meta<typeof RadioBox>

--- a/src/components/molecules/form-fields/form-field.stories.tsx
+++ b/src/components/molecules/form-fields/form-field.stories.tsx
@@ -1,14 +1,15 @@
 import { FormProvider, useForm } from 'react-hook-form'
 import type { Meta, StoryFn } from '@storybook/react'
 
-import { Button, Center, Text } from '@/atoms'
+import { Button, Center, Input, Text } from '@/atoms'
 
 import { Form } from '../form'
 import { FormCard } from '../form-card'
+import { RadioGroupOption } from '../radio-group-options'
 
 import { AmountField } from './amount-field'
 import { InputField } from './input-field'
-import { NumberField } from './number-field'
+import { NumberField, NumberFieldWithSideLabel } from './number-field'
 import { RadioGroupField } from './radio-group-field'
 import { SelectField } from './select-field'
 import { TextareaField } from './textarea-field'
@@ -25,6 +26,12 @@ const options = [
   { label: 'label 3', value: '3' },
 ]
 
+const optionsWithInput: RadioGroupOption[] = [
+  { label: 'label 1', value: '1', description: 'description 1', children: <Input /> },
+  { label: 'label 2', value: '2', description: 'description 2', children: <Input /> },
+  { label: 'label 3', value: '3', description: 'description 3', children: <Input /> },
+]
+
 const Template: StoryFn<typeof FormProvider> = () => {
   const form = useForm()
   return (
@@ -33,11 +40,20 @@ const Template: StoryFn<typeof FormProvider> = () => {
       <FormCard>
         <Form form={form} onSubmit={(vals) => console.info('values: ', vals)}>
           <InputField name="input" label="Input field" required />
-          <InputField name="input2" label="Input field" />
           <NumberField name="number" label="Number field" />
+          <NumberFieldWithSideLabel
+            name="number"
+            label="Number field with Side Label"
+            sideLabel="Side label"
+          />
           <AmountField name="amount" label="Amount field" maxValue="100" denom="regen" />
           <TextareaField name="textarea" label="Textarea field" />
           <RadioGroupField name="radiogroup" label="Radiogroup field" options={options} />
+          <RadioGroupField
+            name="Radio Group with inputs"
+            label="Radiogroup field with children passed"
+            options={optionsWithInput}
+          />
           <SelectField
             name="select"
             label="Select Field"

--- a/src/components/molecules/form-fields/number-field.tsx
+++ b/src/components/molecules/form-fields/number-field.tsx
@@ -3,9 +3,14 @@ import { useController, useFormContext } from 'react-hook-form'
 
 import { strToNumOrEmpty } from 'util/helpers'
 
-import { type NumberInputProps, Flex, NumberInput } from '@/atoms'
+import { type NumberInputProps, Flex, NumberInput, Text } from '@/atoms'
 
 import { type FieldProps, FieldControl } from './field-control'
+
+export type NumberFieldProps = FieldProps & {
+  numberInputProps?: NumberInputProps
+  children?: ReactNode
+}
 
 /** `NumberInput` with controls for react-hook-form */
 /** optionally accepts `children` which will be rendered beside the input */
@@ -13,7 +18,7 @@ export const NumberField = ({
   children,
   numberInputProps,
   ...fieldProps
-}: FieldProps & { numberInputProps?: NumberInputProps; children?: ReactNode }) => {
+}: NumberFieldProps) => {
   const { name, required } = fieldProps
   const { control, getValues } = useFormContext()
   const {
@@ -40,5 +45,20 @@ export const NumberField = ({
         {children}
       </Flex>
     </FieldControl>
+  )
+}
+
+export const NumberFieldWithSideLabel = ({
+  sideLabel,
+  ...numberFieldProps
+}: NumberFieldProps & { sideLabel: string }) => {
+  return (
+    <NumberField {...numberFieldProps}>
+      <Flex align="center" minW="50%">
+        <Text ml={5} fontWeight="bold">
+          {sideLabel}
+        </Text>
+      </Flex>
+    </NumberField>
   )
 }

--- a/src/components/molecules/form-fields/radio-group-field.tsx
+++ b/src/components/molecules/form-fields/radio-group-field.tsx
@@ -1,6 +1,11 @@
 import { useController, useFormContext } from 'react-hook-form'
 
-import { type RadioGroupProps, RadioGroup } from '@/atoms'
+import {
+  type RadioGroupProps,
+  type RadioProps,
+  type StackProps,
+  RadioGroup,
+} from '@/atoms'
 
 import { type RadioGroupOption, RadioGroupOptions } from '../radio-group-options'
 
@@ -9,15 +14,19 @@ import { type FieldProps, FieldControl } from './field-control'
 type Props = FieldProps & {
   options: RadioGroupOption[]
   radioGroupProps?: Omit<RadioGroupProps, 'children' | keyof FieldProps>
+  spacing?: StackProps['spacing']
+  size?: RadioProps['size']
 }
 
-/** custom radio group field for react hook form */
+/** custom radio group field for react hook form - optionally can be passed `children` which will render within the selected radio group option */
 export const RadioGroupField = ({
-  options,
   label,
-  required,
   name,
+  options,
   radioGroupProps,
+  required,
+  size,
+  spacing,
 }: Props) => {
   const { control, getValues } = useFormContext()
   const {
@@ -40,7 +49,12 @@ export const RadioGroupField = ({
         defaultValue={field.value}
         {...radioGroupProps}
       >
-        <RadioGroupOptions options={options} selected={field.value} />
+        <RadioGroupOptions
+          options={options}
+          selected={field.value}
+          spacing={spacing}
+          size={size}
+        />
       </RadioGroup>
     </FieldControl>
   )

--- a/src/components/molecules/radio-group-options.tsx
+++ b/src/components/molecules/radio-group-options.tsx
@@ -1,26 +1,80 @@
-import { type RadioProps, RadioBox, VStack } from '@/atoms'
+import type { ReactNode } from 'react'
+
+import { useColorModeValue } from 'hooks/chakra-hooks'
+
+import { AnimatePresence, motion } from '@/animations'
+import {
+  type RadioProps,
+  type StackProps,
+  Box,
+  Collapse,
+  RadioBox,
+  Text,
+  VStack,
+} from '@/atoms'
 
 export type RadioGroupOption = {
   label: string
+  description?: string
   value: RadioProps['value']
+  children?: ReactNode
 }
 
-type Props = {
+/** can optionally be pasesed a `children` element which will be passed to the selected option */
+export const RadioGroupOptions = ({
+  options,
+  selected,
+  size,
+  spacing,
+}: {
   options: RadioGroupOption[]
   selected: string
-}
-
-export const RadioGroupOptions = ({ options, selected }: Props) => {
+  size?: RadioProps['size']
+  spacing?: StackProps['spacing']
+}) => {
+  const inputBg = useColorModeValue('gray.50', 'gray.800')
+  const inputBgFocused = useColorModeValue('white', 'gray.900')
   return (
-    <VStack align="start" w="full">
-      {options.map(({ value, label }, i) => (
-        <RadioBox
-          key={label + i}
-          selected={selected === value}
-          value={value}
-          label={label}
-        />
-      ))}
+    <VStack spacing={spacing}>
+      {options.map(({ value, description, label, children }, i) => {
+        const isSelected = selected === value
+        return (
+          <RadioBox
+            key={label + i}
+            selected={isSelected}
+            value={value}
+            label={label}
+            size={size}
+            rootProps={{
+              __css: {
+                '* > input': {
+                  bg: inputBg,
+                  '&:focus': {
+                    bg: inputBgFocused,
+                  },
+                },
+              },
+            }}
+          >
+            {(!!description || !!children) && (
+              <Box pt={2} pl={size === 'lg' ? 7 : 6}>
+                {description && <Text>{description}</Text>}
+                <Collapse in={isSelected} animateOpacity style={{ overflow: 'visible' }}>
+                  <AnimatePresence>
+                    {isSelected && !!children ? (
+                      <motion.div key={'box-child-' + label + i}>
+                        <Box pt={3} pb={2}>
+                          {children}
+                        </Box>
+                      </motion.div>
+                    ) : null}
+                  </AnimatePresence>
+                </Collapse>
+              </Box>
+            )}
+          </RadioBox>
+        )
+      })}
     </VStack>
   )
 }

--- a/src/components/organisms/stories/group-policy-form.stories.tsx
+++ b/src/components/organisms/stories/group-policy-form.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryFn } from '@storybook/react'
+
+import { defaultGroupPolicyFormValues } from 'util/form.defaults'
+
+import { GroupPolicyForm } from '../group-policy-form'
+
+export default {
+  title: 'Organisms/GroupPolicyForm',
+  component: GroupPolicyForm,
+  argTypes: {
+    onSubmit: { action: 'onSubmit' },
+  },
+} as Meta<typeof GroupPolicyForm>
+
+const Template: StoryFn<typeof GroupPolicyForm> = (args) => <GroupPolicyForm {...args} />
+
+export const Component = Template.bind({})
+Component.args = {
+  defaultValues: defaultGroupPolicyFormValues,
+}

--- a/src/components/templates/group-crud-template.tsx
+++ b/src/components/templates/group-crud-template.tsx
@@ -55,7 +55,7 @@ export function GroupCRUDTemplate({
   const [submitting, setSubmitting] = useState(false)
   const [priorStep, setPriorStep] = useState(0)
 
-  const { threshold, votingWindow, percentage } = initialPolicyFormValues
+  const { threshold, votingWindow, percentage, policyType } = initialPolicyFormValues
 
   function handleGroupSubmit(values: GroupFormValues) {
     setGroupValues(values)
@@ -99,7 +99,7 @@ export function GroupCRUDTemplate({
           <HorizontalSlide key="step-1">
             <GroupPolicyForm
               onSubmit={handleSubmit}
-              defaultValues={{ threshold, votingWindow, percentage }}
+              defaultValues={{ threshold, votingWindow, percentage, policyType }}
             />
           </HorizontalSlide>
         )

--- a/src/pages/group-edit-page.tsx
+++ b/src/pages/group-edit-page.tsx
@@ -57,6 +57,7 @@ export default function GroupEdit() {
     percentage: isPercentagePolicy(policy.decisionPolicy)
       ? percentStrToNum(policy.decisionPolicy.percentage)
       : undefined,
+    policyType: isThresholdPolicy(decisionPolicy) ? 'threshold' : 'percentage',
   }
 
   const initialValues = {
@@ -112,6 +113,7 @@ export default function GroupEdit() {
             msgUpdateDecisionPolicy({
               admin: group.admin,
               policyAddress: policy.address,
+              policyType: values.policyType,
               votingWindow: values.votingWindow,
               percentage: clearEmptyStr(values.percentage),
               threshold: clearEmptyStr(values.threshold),

--- a/src/util/form.defaults.ts
+++ b/src/util/form.defaults.ts
@@ -30,6 +30,8 @@ export const DEFAULT_MEMBER_WEIGHT = 1
 
 export const defaultGroupPolicyFormValues: GroupPolicyFormValues = {
   votingWindow: DEFAULT_VOTING_WINDOW,
+  policyType: 'threshold',
+  percentage: 51,
 }
 
 export const defaultSendFormValues: ProposalSendFormValues = {


### PR DESCRIPTION
closes: #5 

- modifies `radio-group-options` / `radio-group-field` to allow passing child elements to options, which will render in an animated div under the `RadioBox`'s label
- Converts `GroupPolicyForm` to use this toggle setup
- updates ledger methods

![CleanShot 2023-04-20 at 16 49 14](https://user-images.githubusercontent.com/9052511/233503113-88729dd2-f18c-4e5e-b634-cd44e9e67c45.gif)