### PR TITLE
fix: #11 parse metadata and valid optional

### DIFF
--- a/src/util/validation/metadata.ts
+++ b/src/util/validation/metadata.ts
@@ -5,7 +5,7 @@ import { valid } from './zod'
 const groupMetadataSchema = z.object({
   name: valid.name,
   description: valid.description.optional().or(z.literal('')),
-  updatedAt: z.string(),
+  updatedAt: z.string().optional(),
   forumLink: valid.url.optional().or(z.literal('')),
   other: z.string().optional(),
 })

--- a/src/util/validation/metadata.ts
+++ b/src/util/validation/metadata.ts
@@ -4,9 +4,9 @@ import { valid } from './zod'
 
 const groupMetadataSchema = z.object({
   name: valid.name,
-  description: valid.description.optional(),
+  description: valid.description.optional().or(z.literal('')),
   updatedAt: z.string(),
-  forumLink: valid.url.optional(),
+  forumLink: valid.url.optional().or(z.literal('')),
   other: z.string().optional(),
 })
 export type UIGroupMetadata = z.infer<typeof groupMetadataSchema>
@@ -20,7 +20,8 @@ export function getGroupMetadata(
   defaults?: UIGroupMetadata,
 ): UIGroupMetadata {
   if (isGroupMetadata(metadata)) return metadata
-  const parsed = JSON.parse(JSON.stringify(metadata))
+  // NOTE: double parsing is required when value is stringified
+  const parsed = JSON.parse(JSON.parse(JSON.stringify(metadata)))
   if (isGroupMetadata(parsed)) return parsed
   return {
     name: '',
@@ -44,7 +45,8 @@ export function getProposalMetadata(
   defaults?: Partial<UIProposalMetadata>,
 ): UIProposalMetadata {
   if (isProposalMetadata(metadata)) return metadata
-  const parsed = JSON.parse(JSON.stringify(metadata))
+  // NOTE: double parsing is required when value is stringified
+  const parsed = JSON.parse(JSON.parse(JSON.stringify(metadata)))
   if (isProposalMetadata(parsed)) return parsed
   return {
     title: '',


### PR DESCRIPTION
This pull request fixes parsing metadata and allows empty string on optional values.

All groups and proposals are currently not passing as valid metadata because we are stringifying the metadata before parsing, which produces another string rather than an object. [The solution is to parse twice](https://stackoverflow.com/questions/42494823/json-parse-returns-string-instead-of-object).

When using `valid`, we are not respecting the optional values. A group with a valid name but no description (i.e. empty string) was not passing validation. A group with a valid name but no forum link (i.e. empty string) was not passing validation.

Also, a group created outside the UI with metadata that does not include `updatedAt` but has a valid name was not passing validation. Making `updatedAt` optional allows the name to be displayed and "Last Edited" to be empty.