### PR TITLE
fix: #9 empty messages in proposal response

### DIFF
--- a/src/api/proposal.utils.ts
+++ b/src/api/proposal.utils.ts
@@ -53,10 +53,14 @@ export function toUIProposal(sdkProposal: ProposalSDKType): UIProposal {
     groupPolicyVersion: sdkProposal.group_policy_version,
     groupVersion: sdkProposal.group_version,
     id: sdkProposal.id,
-    messages: sdkProposal.messages.map((msg) => ({
-      typeUrl: msg.type_url,
-      value: msg.value,
-    })),
+    // TODO(#9): dependent on https://github.com/regen-network/regen-js/issues/71
+    messages: sdkProposal.messages.map(
+      (msg: any) =>
+        ({
+          typeUrl: msg['@type'],
+          value: msg,
+        } as Any),
+    ),
     metadata: getProposalMetadata(sdkProposal.metadata, {
       title: `Proposal #${sdkProposal.id}`,
     }),


### PR DESCRIPTION
Ref: #9

This implements a workaround for an upstream issue in the telescope package (and therefore regen-js `api` package).