### PR TITLE
fix: #75 parse group and proposal id from event

### DIFF
--- a/src/api/group.actions.ts
+++ b/src/api/group.actions.ts
@@ -1,3 +1,4 @@
+import { Event } from '@regen-network/api/types/codegen/tendermint/abci/types'
 import Long from 'long'
 
 import type { GroupWithPolicyFormValues, UIGroup } from 'types'

--- a/src/api/group.actions.ts
+++ b/src/api/group.actions.ts
@@ -11,21 +11,18 @@ import { msgCreateGroupWithPolicy } from './group.messages'
 import { addMembersToGroups, toUIGroup } from './group.utils'
 
 export async function createGroupWithPolicy(values: GroupWithPolicyFormValues) {
-  try {
-    const msg = msgCreateGroupWithPolicy(values)
-    const data = await signAndBroadcast([msg])
-    let groupId
-    if (data.rawLog && isJson(data.rawLog)) {
-      const [raw] = JSON.parse(data.rawLog)
-      const idRaw = raw.events[0].attributes[0].value
-      if (idRaw && isJson(idRaw)) {
-        groupId = String(JSON.parse(idRaw))
-      }
+  const msg = msgCreateGroupWithPolicy(values)
+  const data = await signAndBroadcast([msg])
+  if (!data) throwError('No data returned from transaction')
+  let groupId
+  if (data.rawLog && isJson(data.rawLog)) {
+    const [raw] = JSON.parse(data.rawLog)
+    const idRaw = raw.events[0].attributes[0].value
+    if (idRaw && isJson(idRaw)) {
+      groupId = String(JSON.parse(idRaw))
     }
-    return { ...data, groupId }
-  } catch (error) {
-    throwError(error)
   }
+  return { ...data, groupId }
 }
 
 export async function fetchGroupsWithMembersByMember(address?: string) {

--- a/src/api/group.actions.ts
+++ b/src/api/group.actions.ts
@@ -17,10 +17,10 @@ export async function createGroupWithPolicy(values: GroupWithPolicyFormValues) {
   let groupId
   if (data.rawLog && isJson(data.rawLog)) {
     const [raw] = JSON.parse(data.rawLog)
-    const idRaw = raw.events[0].attributes[0].value
-    if (idRaw && isJson(idRaw)) {
-      groupId = String(JSON.parse(idRaw))
-    }
+    const idRaw = raw.events.find(
+      (e: Event) => e.type === 'cosmos.group.v1.EventCreateGroup',
+    ).attributes[0].value
+    groupId = String(JSON.parse(idRaw))
   }
   return { ...data, groupId }
 }

--- a/src/api/group.actions.ts
+++ b/src/api/group.actions.ts
@@ -11,10 +11,12 @@ import { signAndBroadcast } from 'store/wallet.store'
 import { msgCreateGroupWithPolicy } from './group.messages'
 import { addMembersToGroups, toUIGroup } from './group.utils'
 
+const txError = 'No data returned from transaction'
+
 export async function createGroupWithPolicy(values: GroupWithPolicyFormValues) {
   const msg = msgCreateGroupWithPolicy(values)
   const data = await signAndBroadcast([msg])
-  if (!data) throwError('No data returned from transaction')
+  if (!data) throwError(txError)
   let groupId
   if (data.rawLog && isJson(data.rawLog)) {
     const [raw] = JSON.parse(data.rawLog)

--- a/src/api/policy.messages.ts
+++ b/src/api/policy.messages.ts
@@ -51,7 +51,8 @@ export function encodeDecisionPolicy({
 }) {
   const windows = {
     minExecutionPeriod: secondsToDuration(1),
-    votingPeriod: daysToDuration(votingWindow),
+    // TODO: undo change before merging
+    votingPeriod: secondsToDuration(votingWindow), // daysToDuration(votingWindow),
   }
   if (policyType === 'percentage') {
     if (!percentage) throwError('Must provide percentage value')

--- a/src/api/policy.messages.ts
+++ b/src/api/policy.messages.ts
@@ -51,8 +51,7 @@ export function encodeDecisionPolicy({
 }) {
   const windows = {
     minExecutionPeriod: secondsToDuration(1),
-    // TODO: undo change before merging
-    votingPeriod: secondsToDuration(votingWindow), // daysToDuration(votingWindow),
+    votingPeriod: daysToDuration(votingWindow),
   }
   if (policyType === 'percentage') {
     if (!percentage) throwError('Must provide percentage value')

--- a/src/api/proposal.actions.ts
+++ b/src/api/proposal.actions.ts
@@ -128,7 +128,7 @@ export async function voteOnProposal({
     metadata: '',
   })
   const data = await signAndBroadcast([msg])
-  if (!data) throwError('No data returned from vote')
+  if (!data) throwError('No data returned from transaction')
   return data
 }
 

--- a/src/api/proposal.actions.ts
+++ b/src/api/proposal.actions.ts
@@ -1,3 +1,4 @@
+import { Event } from '@regen-network/api/types/codegen/tendermint/abci/types'
 import Long from 'long'
 
 import type {
@@ -92,7 +93,7 @@ export async function createProposal({
   if (data.rawLog && isJson(data.rawLog)) {
     const [raw] = JSON.parse(data.rawLog)
     const idRaw = raw.events.find(
-      (e: any) => e.type === 'cosmos.group.v1.EventSubmitProposal',
+      (e: Event) => e.type === 'cosmos.group.v1.EventSubmitProposal',
     ).attributes[0].value
     proposalId = String(JSON.parse(idRaw))
   }

--- a/src/api/proposal.actions.ts
+++ b/src/api/proposal.actions.ts
@@ -17,6 +17,8 @@ import { GroupMsgWithTypeUrl } from './cosmosgroups'
 import { msgSubmitProposal } from './proposal.messages'
 import { proposalActionsToMsgs, toUIProposal, toUIVote } from './proposal.utils'
 
+const txError = 'No data returned from transaction'
+
 export async function fetchProposalsByGroupPolicy(address?: string) {
   if (!Query.groups) throwError('Wallet not initialized')
   if (!address) throwError('Address is required')
@@ -88,7 +90,7 @@ export async function createProposal({
     metadata: JSON.stringify(metadata),
   })
   const data = await signAndBroadcast([submitMsg])
-  if (!data) throwError('No data returned from transaction')
+  if (!data) throwError(txError)
   let proposalId: string | undefined
   if (data.rawLog && isJson(data.rawLog)) {
     const [raw] = JSON.parse(data.rawLog)
@@ -97,7 +99,7 @@ export async function createProposal({
     ).attributes[0].value
     proposalId = String(JSON.parse(idRaw))
   }
-  if (!proposalId) throwError('No data returned from transaction')
+  if (!proposalId) throwError(txError)
   return { ...data, proposalId }
 }
 
@@ -108,7 +110,7 @@ export async function executeProposal({ proposalId }: { proposalId: Long }) {
     executor: Wallet.account.address,
   })
   const data = await signAndBroadcast([msg])
-  if (!data) throwError('No data returned from transaction')
+  if (!data) throwError(txError)
   return data
 }
 
@@ -128,7 +130,7 @@ export async function voteOnProposal({
     metadata: '',
   })
   const data = await signAndBroadcast([msg])
-  if (!data) throwError('No data returned from transaction')
+  if (!data) throwError(txError)
   return data
 }
 

--- a/src/pages/group-create-page.tsx
+++ b/src/pages/group-create-page.tsx
@@ -18,7 +18,7 @@ export default function GroupCreate() {
     try {
       const { transactionHash, groupId } = await createGroupWithPolicy(values)
       setNewGroupId(groupId?.toString())
-      toastSuccess(transactionHash, 'Group created!')
+      toastSuccess(transactionHash)
       return true
     } catch (err) {
       logError(err)

--- a/src/pages/group-page.tsx
+++ b/src/pages/group-page.tsx
@@ -36,8 +36,8 @@ export default function GroupPage() {
 
   const handleExecute = async (proposal: UIProposal) => {
     try {
-      const data = await executeProposal({ proposalId: proposal.id })
-      toastSuccess(data?.transactionHash || '')
+      const { transactionHash } = await executeProposal({ proposalId: proposal.id })
+      toastSuccess(transactionHash)
     } catch (err) {
       toastErr(err)
     }

--- a/src/pages/proposal-create-page.tsx
+++ b/src/pages/proposal-create-page.tsx
@@ -75,7 +75,7 @@ export default function ProposalCreate() {
       })
       if (!data?.proposalId)
         throwError('Proposal transaction completed, but no proposal ID found')
-      toastSuccess(data.transactionHash, 'Proposal created!')
+      toastSuccess(data.transactionHash)
       return data.proposalId
     } catch (error) {
       logError(error)

--- a/src/pages/proposal-page.tsx
+++ b/src/pages/proposal-page.tsx
@@ -50,8 +50,8 @@ export default function ProposalPage() {
   async function handleVote(option: VoteOptionType) {
     if (!proposalId) throwError('Proposal ID is required to cast vote')
     try {
-      await voteOnProposal({ proposalId, option })
-      toastSuccess('Vote cast successfully')
+      const { transactionHash } = await voteOnProposal({ proposalId, option })
+      toastSuccess(transactionHash)
       refetchVotes()
       refetchUserVotes()
     } catch (err) {


### PR DESCRIPTION
Closes: #75

While looking into #56, I discovered that we were logging errors from transactions rather than displaying the error using the toast error. We don't need a try catch for transactions and we should be throwing an error rather than logging with queries. Without the try catch, the user receives more information such as the following:

![Screenshot from 2023-06-05 14-32-50](https://github.com/regen-network/groups-ui/assets/12519942/2fbd8586-2663-45c7-be26-befd47413c19)

Also, the toast success message is set up for a transaction hash, so this pull request ensures the success message is always the transaction hash. The issue with #75 was we were expecting the proposal id value to be valid json using the new `isJson` helper but the event attribute will always be a string with escape characters so we don't need strict validation.