### PR TITLE
fix: validator not displayed in stake messages

### DIFF
--- a/src/components/organisms/proposal-summary.tsx
+++ b/src/components/organisms/proposal-summary.tsx
@@ -136,6 +136,7 @@ function renderMessage(msg: any, groupPolicyAddress: string) {
               stakeType: 'delegate',
               amount: msg.value['amount']['amount'],
               denom: msg.value['amount']['denom'],
+              validator: msg.value['validator_address'],
             } as unknown as ProposalStakeFormValues
           }
         />
@@ -150,6 +151,8 @@ function renderMessage(msg: any, groupPolicyAddress: string) {
               stakeType: 'redelegate',
               amount: msg.value['amount']['amount'],
               denom: msg.value['amount']['denom'],
+              toValidator: msg.value['validator_dst_address'],
+              fromValidator: msg.value['validator_src_address'],
             } as unknown as ProposalStakeFormValues
           }
         />
@@ -164,6 +167,7 @@ function renderMessage(msg: any, groupPolicyAddress: string) {
               stakeType: 'undelegate',
               amount: msg.value['amount']['amount'],
               denom: msg.value['amount']['denom'],
+              validator: msg.value['validator_address'],
             } as unknown as ProposalStakeFormValues
           }
         />


### PR DESCRIPTION
Closes: #108

This pull request fixes the display of validator addresses when reviewing stake proposals.

Examples:

- https://deploy-preview-119--regen-groups-ui.netlify.app/37/proposals/72
- https://deploy-preview-119--regen-groups-ui.netlify.app/37/proposals/73
- https://deploy-preview-119--regen-groups-ui.netlify.app/37/proposals/74
- https://deploy-preview-119--regen-groups-ui.netlify.app/37/proposals/75