### PR TITLE
fix: display group if indexer unavailable

### DIFF
--- a/src/hooks/use-query.ts
+++ b/src/hooks/use-query.ts
@@ -124,15 +124,21 @@ export function useGroupHistoricalProposals(groupId?: string) {
       }
       const result = []
       for (const address of policyIds) {
-        const res = await client.request(ProposalsByGroupPolicyAddressDocument, {
-          groupPolicyAddress: address,
-        })
-        if (!!res.allProposals && !!res.allProposals.nodes) {
-          const { nodes } = res.allProposals
-          for (const node of nodes) {
-            const uiProposal = nodeToUIProposal(node)
-            result.push(uiProposal)
+        // NOTE: We use a try-catch statement to prevent the application from being dependent on
+        // indexed proposals being available (i.e. a successful request to the graphql endpoint).
+        try {
+          const res = await client.request(ProposalsByGroupPolicyAddressDocument, {
+            groupPolicyAddress: address,
+          })
+          if (!!res.allProposals && !!res.allProposals.nodes) {
+            const { nodes } = res.allProposals
+            for (const node of nodes) {
+              const uiProposal = nodeToUIProposal(node)
+              result.push(uiProposal)
+            }
           }
+        } catch (e) {
+          console.error(e)
         }
       }
       return result


### PR DESCRIPTION
Closes: #134

This pull request updates how we handle the error from the graphql endpoint when fetching historical proposals. If the graphql endpoint is unavailable, group pages will load successfully without historical proposals and the error from the graphql request will be logged to the console rather than being thrown (preventing the page from being viewed without historical proposals).