### PR TITLE
fix: don't throw ipfs errors, use defaults

### DIFF
--- a/src/api/ipfs.actions.ts
+++ b/src/api/ipfs.actions.ts
@@ -1,6 +1,5 @@
 import { create as createIpfsClient } from 'ipfs-http-client'
 
-import { throwError } from 'util/errors'
 import { isJson } from 'util/validation'
 
 const client = createIpfsClient({
@@ -20,6 +19,6 @@ export async function fetchIpfsData(cid: string) {
     const dataStr = data.toString()
     return isJson(dataStr) ? JSON.parse(dataStr) : dataStr
   } catch (error) {
-    throwError(error)
+    console.log({ error, cid, message: 'unable to fetch ipfs data' })
   }
 }


### PR DESCRIPTION
Closes: #146 

Testing:

1. create a proposal with an invalid ipfs url for a group policy address i.e.

```
➜  ~ cat proposal.json 
{
  "@type": "/cosmos.group.v1.MsgSubmitProposal",
  "group_policy_address": "regen1mqevjln5hxv3qgd3c4m5zjeeand5hkc7r33ty82fjukw9shxjh6s6d4umv",
  "proposers": ["regen1fhjpuh6qh6kjsedtmfxrayvmzlknkzde92ky2j"],
  "metadata": "ipfs://CID",
  "messages": [],
  "exec": "EXEC_UNSPECIFIED"
}
```

2. submit the proposal via cli i.e.

```
➜  ~ ~/go/bin/regen tx group submit-proposal proposal.json --keyring-backend test --chain-id test 
```

3. Go to the page for the group in the groups-ui, observe that the group page and proposal page loads successfully.

4. Checkout `dev`, repeat 1-3, observe the failure.